### PR TITLE
Changed get_s0 to get_unit_s0 in geometry viewer when setting beam di…

### DIFF
--- a/command_line/geometry_viewer.py
+++ b/command_line/geometry_viewer.py
@@ -73,7 +73,7 @@ class render_3d:
             gonio = self.imageset.get_goniometer()
             axis = matrix.col(gonio.get_rotation_axis()).elems
             self.viewer.set_rotation_axis(axis)
-        self.viewer.set_beam_vector(self.imageset.get_beam().get_s0())
+        self.viewer.set_beam_vector(self.imageset.get_beam().get_unit_s0())
 
         self.set_points()
 
@@ -491,7 +491,7 @@ class GeometryWindow(wx_viewer.show_points_and_lines_mixin):
         elif gonio is not None:
             axis = matrix.col(gonio.get_rotation_axis())
             self.draw_axis(axis.elems, "phi")
-        self.draw_axis(beam.get_s0(), "beam")
+        self.draw_axis(beam.get_unit_s0(), "beam")
         crystal = self.parent.crystal
         if self.settings.show_crystal_axes and crystal is not None:
             crystal = copy.deepcopy(crystal)


### PR DESCRIPTION
Changed get_s0 to get_unit_s0 in geometry viewer when setting beam direction, to ensure it works for TOFBeam with no code changes.