### PR TITLE
Image viewer line plot

### DIFF
--- a/array_family/flex_ext.py
+++ b/array_family/flex_ext.py
@@ -1030,10 +1030,8 @@ class _:
                 return False
         return True
 
-    coord = [int, int]
-
     def get_pixel_bbox_centroid_positions(
-        self, panel: int, pixel_pos: coord
+        self, panel: int, pixel_pos: Tuple[int, int]
     ) -> Tuple[list, list]:
 
         """

--- a/array_family/flex_ext.py
+++ b/array_family/flex_ext.py
@@ -1030,6 +1030,23 @@ class _:
                 return False
         return True
 
+    coord = [int, int]
+
+    def get_pixel_bbox_positions(self, panel: int, pixel_pos: coord) -> list:
+        """
+        Finds any bounding boxes within px and py on panel and returns their pz positions
+        """
+        sel = self["panel"] == panel
+        x0, x1, y0, y1, z0, z1 = self["bbox"].select(sel).parts()
+        py = int(pixel_pos[0])
+        px = int(pixel_pos[1])
+        bbox_pos = []
+        for i in range(len(x0)):
+            if px >= x0[i] and px <= x1[i]:
+                if py >= y0[i] and py <= y1[i]:
+                    bbox_pos.append([z0[i], z1[i]])
+        return bbox_pos
+
     def find_overlaps(self, experiments=None, border=0):
         """
         Check for overlapping reflections.

--- a/array_family/flex_ext.py
+++ b/array_family/flex_ext.py
@@ -1032,20 +1032,28 @@ class _:
 
     coord = [int, int]
 
-    def get_pixel_bbox_positions(self, panel: int, pixel_pos: coord) -> list:
+    def get_pixel_bbox_centroid_positions(
+        self, panel: int, pixel_pos: coord
+    ) -> Tuple[list, list]:
+
         """
-        Finds any bounding boxes within px and py on panel and returns their pz positions
+        Finds any bounding boxes within px and py on panel and returns their pz positions along with
+        the centroid pz position.
         """
+
         sel = self["panel"] == panel
         x0, x1, y0, y1, z0, z1 = self["bbox"].select(sel).parts()
+        centroids = self["shoebox"].select(sel).centroid_valid()
         py = int(pixel_pos[0])
         px = int(pixel_pos[1])
         bbox_pos = []
+        centroid_pos = []
         for i in range(len(x0)):
             if px >= x0[i] and px <= x1[i]:
                 if py >= y0[i] and py <= y1[i]:
                     bbox_pos.append([z0[i], z1[i]])
-        return bbox_pos
+                    centroid_pos.append(centroids[i].px.position[2])
+        return bbox_pos, centroid_pos
 
     def find_overlaps(self, experiments=None, border=0):
         """

--- a/newsfragments/5.feature
+++ b/newsfragments/5.feature
@@ -1,0 +1,1 @@
+Added pixel line plot to dials.image_viewer

--- a/util/image_viewer/slip_viewer/frame.py
+++ b/util/image_viewer/slip_viewer/frame.py
@@ -133,6 +133,8 @@ class XrayFrame(XFBaseClass):
         self.SetMinSize(self.GetSize())
         self.SetSize((720, 720))
 
+        self.current_image_coords = None
+
         self.Bind(EVT_EXTERNAL_UPDATE, self.OnExternalUpdate)
 
         self.Bind(wx.EVT_UPDATE_UI, self.OnUpdateUICalibration, id=self._id_calibration)
@@ -215,6 +217,7 @@ class XrayFrame(XFBaseClass):
                 if len(coords) == 2:
                     posn_str += " Readout: " + coords_str + "."
                 elif readout >= 0:
+                    self.current_image_coords = (readout, coords)
                     posn_str += " Readout %d: %s." % (readout, coords_str)
 
                 possible_intensity = None

--- a/util/image_viewer/slip_viewer/frame.py
+++ b/util/image_viewer/slip_viewer/frame.py
@@ -359,7 +359,7 @@ class XrayFrame(XFBaseClass):
         # FIXME assumes all detector elements use the same millimeter-to-pixel convention
         try:
             # determine if the beam intersects one of the panels
-            panel_id, (x_mm, y_mm) = detector.get_ray_intersection(beam.get_s0())
+            panel_id, (x_mm, y_mm) = detector.get_ray_intersection(beam.get_unit_s0())
         except RuntimeError as e:
             if not ("DXTBX_ASSERT(" in str(e) and ") failure" in str(e)):
                 # unknown exception from dxtbx
@@ -369,11 +369,13 @@ class XrayFrame(XFBaseClass):
             lowest_res = 0
             for p_id, panel in enumerate(detector):
                 w, h = panel.get_image_size()
-                res = panel.get_resolution_at_pixel(beam.get_s0(), (w // 2, h // 2))
+                res = panel.get_resolution_at_pixel(
+                    beam.get_unit_s0(), (w // 2, h // 2)
+                )
                 if res > lowest_res:
                     panel_id = p_id
                     lowest_res = res
-            x_mm, y_mm = detector[panel_id].get_beam_centre(beam.get_s0())
+            x_mm, y_mm = detector[panel_id].get_beam_centre(beam.get_unit_s0())
 
         beam_pixel_fast, beam_pixel_slow = detector[panel_id].millimeter_to_pixel(
             (x_mm, y_mm)

--- a/util/image_viewer/slip_viewer/frame.py
+++ b/util/image_viewer/slip_viewer/frame.py
@@ -215,10 +215,6 @@ class XrayFrame(XFBaseClass):
                 if len(coords) == 2:
                     posn_str += " Readout: " + coords_str + "."
                 elif readout >= 0:
-                    bboxes = self.reflections[0].get_pixel_bbox_positions(
-                        readout, coords
-                    )
-                    self.pixel_line_plot.draw(readout, coords, bboxes)
                     posn_str += " Readout %d: %s." % (readout, coords_str)
 
                 possible_intensity = None

--- a/util/image_viewer/slip_viewer/frame.py
+++ b/util/image_viewer/slip_viewer/frame.py
@@ -215,6 +215,10 @@ class XrayFrame(XFBaseClass):
                 if len(coords) == 2:
                     posn_str += " Readout: " + coords_str + "."
                 elif readout >= 0:
+                    bboxes = self.reflections[0].get_pixel_bbox_positions(
+                        readout, coords
+                    )
+                    self.pixel_line_plot.draw(readout, coords, bboxes)
                     posn_str += " Readout %d: %s." % (readout, coords_str)
 
                 possible_intensity = None

--- a/util/image_viewer/slip_viewer/tile_generation.py
+++ b/util/image_viewer/slip_viewer/tile_generation.py
@@ -108,7 +108,9 @@ def get_flex_image_multipanel(
     npanels = 0
     for panel in detector:
         try:
-            beam_center += scitbx.matrix.col(panel.get_beam_centre_lab(beam.get_s0()))
+            beam_center += scitbx.matrix.col(
+                panel.get_beam_centre_lab(beam.get_unit_s0())
+            )
             npanels += 1
         except RuntimeError:  # catch DXTBX_ASSERT for no intersection
             pass
@@ -582,7 +584,7 @@ class _Tiles:
         beam = self.raw_image.get_beam()
         if detector is None or beam is None:
             return None
-        beam = beam.get_s0()
+        beam = beam.get_unit_s0()
 
         if readout is None:
             return None

--- a/util/image_viewer/spotfinder_frame.py
+++ b/util/image_viewer/spotfinder_frame.py
@@ -84,261 +84,6 @@ def create_load_image_event(destination, filename):
     wx.PostEvent(destination, LoadImageEvent(myEVT_LOADIMG, -1, filename))
 
 
-class PixelLinePlot(wx.Frame):
-    def __init__(self, parent, experiment, **kwargs):
-
-        wx.Frame.__init__(self, parent=parent)
-        self.experiment = experiment
-        self.properties = self.get_properties(**kwargs)
-
-        # Setup blank plot
-        self.figure = Figure(
-            figsize=(self.properties["figsize"]), facecolor=self.properties["facecolor"]
-        )
-        self.axes = self.figure.add_subplot(111)
-        self.canvas = FigureCanvas(self, -1, self.figure)
-        self.sizer = wx.BoxSizer(wx.HORIZONTAL)
-        self.sizer.Add(self.canvas, 1, wx.EXPAND)
-        self.SetSizer(self.sizer)
-        self.axes.set_xlabel(self.properties["xlabel"])
-        self.axes.set_ylabel(self.properties["ylabel"])
-        self.axes.set_ylim(self.properties["default_ylim"])
-        self.axes.set_xlim(self.properties["default_xlim"])
-        self.axes.patch.set_facecolor(self.properties["facecolor"])
-
-        # Params for zooming
-        self.base_zoom_level = 2.0
-
-        # Params for panning
-        self.press = None
-        self.xpress = None
-        self.ypress = None
-        self.x0 = None
-        self.y0 = None
-        self.x1 = None
-        self.y1 = None
-
-        # Bookkeeping to avoid zooming/pannning out of range
-        self.x_range = None
-        self.y_range = None
-
-        # Binding for event handlers
-        self.figure.canvas.mpl_connect("scroll_event", self.zoom_handler)
-        self.figure.canvas.mpl_connect("button_press_event", self.on_press_handler)
-        self.figure.canvas.mpl_connect("button_release_event", self.on_release_handler)
-        self.figure.canvas.mpl_connect("motion_notify_event", self.on_motion_handler)
-        self.Bind(wx.EVT_CLOSE, self.close_window_handler)
-
-        self.Show()
-
-    def close_window_handler(self, event) -> None:
-        self.GetParent().pixel_line_plot_closed()
-        self.Destroy()
-
-    def on_press_handler(self, event) -> None:
-
-        """
-        Press handler for panning
-        """
-
-        if event.inaxes != self.axes:
-            return
-        self.press = self.x0, self.y0, event.xdata, event.ydata
-        self.x0, self.y0, self.xpress, self.ypress = self.press
-
-    def on_release_handler(self, event) -> None:
-
-        """
-        Release handler for panning
-        """
-
-        self.press = None
-        self.canvas.draw()
-
-    def on_motion_handler(self, event, x_only: bool = True) -> None:
-
-        """
-        Motion handler for panning.
-        If x_only, panning is disabled for the y axis.
-        """
-
-        # Sanity check the event should be processed
-        if self.x_range is None or self.y_range is None:
-            return
-        if self.press is None:
-            return
-        if event.inaxes != self.axes:
-            return
-
-        # Handle x axis
-        dx = event.xdata - self.xpress
-        new_x = self.axes.get_xlim() - dx
-        # Only pan if within the range of data
-        if new_x[0] > self.x_range[0] and new_x[1] < self.x_range[1]:
-            self.axes.set_xlim(new_x)
-        if x_only:
-            self.canvas.draw()
-            return
-
-        # Handle y axis
-        dy = event.ydata - self.ypress
-        new_y = self.axes.get_ylim() - dy
-        # Only pan if within the range of data
-        if new_y[0] > self.yrange[0] and new_y[1] < self.y_range[1]:
-            self.axes.set_ylim(new_y)
-
-        self.canvas.draw()
-
-    def zoom_handler(self, event, x_only: bool = True) -> None:
-
-        """
-        Handles all zooming events, bound to the mouse wheel.
-        If x_only, ylim remains constant.
-        """
-
-        # Sanity check event should be processed
-        if self.x_range is None or self.y_range is None:
-            return
-
-        xdata = event.xdata
-        ydata = event.ydata
-
-        if xdata is None or ydata is None:
-            return
-
-        # Get current limits
-        cur_xlim = self.axes.get_xlim()
-        cur_ylim = self.axes.get_ylim()
-
-        # Zoom in
-        if event.button == "down":
-            scale_factor = 1 / self.base_zoom_level
-        # Zoom out
-        elif event.button == "up":
-            scale_factor = self.base_zoom_level
-        # Should never happen
-        else:
-            scale_factor = 1
-
-        # Get new x range and clamp to max x range
-        new_width = (cur_xlim[1] - cur_xlim[0]) * scale_factor
-        new_height = (cur_ylim[1] - cur_ylim[0]) * scale_factor
-
-        relx = (cur_xlim[1] - xdata) / (cur_xlim[1] - cur_xlim[0])
-        rely = (cur_ylim[1] - ydata) / (cur_ylim[1] - cur_ylim[0])
-
-        new_xmin = xdata - new_width * (1 - relx)
-
-        # Clamp to maximum zoom out level
-        if new_xmin < self.x_range[0]:
-            new_xmin = self.x_range[0]
-        new_xmax = xdata + new_width * (relx)
-        if new_xmax > self.x_range[1]:
-            new_xmax = self.x_range[1]
-
-        # Do nothing if trying to zoom in beyond maximum level
-        if new_xmax - new_xmin < self.properties["min_delta_x_range"]:
-            return
-
-        if x_only:
-            self.axes.set_xlim([new_xmin, new_xmax])
-            self.canvas.draw()
-            return
-
-        # Get new y range and clamp to max y range
-        new_ymin = ydata - new_height * (1 - rely)
-        if new_ymin < self.y_range[0]:
-            new_ymin = self.y_range[0]
-        new_ymax = ydata + new_height * (rely)
-        if new_ymax > self.y_range[1]:
-            new_ymax = self.y_range[1]
-
-        # Do nothing if trying to zoom in beyond maximum level
-        if new_ymax - new_ymin < self.properties["min_delta_y_range"]:
-            return
-
-        self.axes.set_ylim([new_ymin, new_ymax])
-
-    def get_properties(self, **kwargs) -> Dict[str, Union[str, int, Tuple]]:
-
-        """
-        Where all plot params are set.
-        """
-
-        default_values = {
-            "facecolor": "#FFE4E4",
-            "linecolor": "black",
-            "bboxcolor": "blue",
-            "centroid_marker_color": "red",
-            "centroid_marker": "x",
-            "centroid_markersize": 15,
-            "figsize": (10, 0.5),
-            "xlabel": "ToF (usec)",
-            "ylabel": "Intensity (AU)",
-            "min_delta_y_range": 1,
-            "min_delta_x_range": 500,
-            "default_xlim": (0, 17500),
-            "default_ylim": (0, 1000),
-        }
-        graph_properties = dict(default_values)
-        graph_properties.update(kwargs)
-        return graph_properties
-
-    def draw(
-        self,
-        panel_idx: int,
-        coords: Tuple,
-        bboxes: Tuple = None,
-        centroids: Tuple = None,
-    ) -> None:
-
-        """
-        Updates the plot with a line plot at coords from panel panel_idx.
-        If bboxes or centroids are given, these are also added to the plot.
-        """
-        px = int(coords[0])
-        py = int(coords[1])
-        x, spectra = self.experiment.imageset.get_pixel_spectra(panel_idx, px, py)
-        self.x_range = (min(x), max(x))
-        self.y_range = (min(spectra), max(spectra))
-        self.axes.cla()
-        self.axes.plot(x, spectra, c=self.properties["linecolor"])
-        if bboxes:
-            for bbox in bboxes:
-                x0 = x[bbox[0]]
-                x1 = x[bbox[1]]
-                y0 = min(spectra[bbox[0] : bbox[1]])
-                y1 = max(spectra[bbox[0] : bbox[1]])
-                self.axes.plot(
-                    [x0, x0, x1, x1],
-                    [y0, y1, y1, y0],
-                    lw=1,
-                    c=self.properties["bboxcolor"],
-                )
-        if centroids:
-            for centroid in centroids:
-                cx = x[int(centroid)]
-                cy = spectra[int(centroid)]
-                self.axes.plot(
-                    [cx],
-                    [cy],
-                    self.properties["centroid_marker"],
-                    markersize=self.properties["centroid_markersize"],
-                    c=self.properties["centroid_marker_color"],
-                )
-
-        self.axes.set_title(f"panel {panel_idx} at ({px}, {py})")
-        self.axes.set_xlabel(self.properties["xlabel"])
-        self.axes.set_ylabel(self.properties["ylabel"])
-        self.axes.set_xlim(self.x_range)
-        if self.y_range[1] < self.properties["default_ylim"][1]:
-            self.axes.set_ylim(self.properties["default_ylim"])
-        else:
-            self.axes.set_ylim(self.y_range)
-        self.axes.patch.set_facecolor(self.properties["facecolor"])
-        self.canvas.draw()
-
-
 class SpotFrame(XrayFrame):
     def __init__(self, *args, **kwds):
         self.experiments = kwds.pop("experiments")
@@ -470,16 +215,37 @@ class SpotFrame(XrayFrame):
         self.Bind(wx.EVT_UPDATE_UI, self.OnUpdateUIMask, id=self._id_mask)
         self.Bind(EVT_ZEROMQ_EVENT, self.OnZeroMQEvent)
 
-    def get_pixel_line_plot(self, **kwargs) -> PixelLinePlot:
+    def get_pixel_line_plot(self, imageset: ImageSet, **kwargs):
 
         """
         Creates and returns a pixel line plot
         """
 
-        pixel_line_plot = PixelLinePlot(self, self.experiments[0][0], kwargs=kwargs)
+        pixel_line_plot = PixelLinePlot(self, imageset, kwargs=kwargs)
         pixel_line_plot.SetSize(1024, 450)
         pixel_line_plot.SetPosition((0, self.GetSize()[0] - 500))
         return pixel_line_plot
+
+    def update_pixel_line_plot(self) -> None:
+
+        """
+        Update to pixel line plot when self.update_settings is called.
+
+        """
+
+        imageset = self.images.selected.image_set
+
+        # Create a new pixel line plot if not active and one is requested
+        if self.settings.show_pixel_line_plot and not self.pixel_line_plot:
+            self.pixel_line_plot = self.get_pixel_line_plot(imageset)
+        elif self.pixel_line_plot:
+            # Close the active pixel line plot if requested
+            if not self.settings.show_pixel_line_plot:
+                self.pixel_line_plot.Close()
+                self.pixel_line_plot = None
+            # Ensure current image is from pixel_line_plot.imageset
+            elif imageset is not self.pixel_line_plot.imageset:
+                self.pixel_line_plot.update_imageset(imageset)
 
     def pixel_line_plot_closed(self) -> None:
 
@@ -1351,11 +1117,7 @@ class SpotFrame(XrayFrame):
             self.pyslip.DeleteLayer(self.beam_layer, update=False)
             self.beam_layer = None
 
-        if self.settings.show_pixel_line_plot and not self.pixel_line_plot:
-            self.pixel_line_plot = self.get_pixel_line_plot()
-        elif not self.settings.show_pixel_line_plot and self.pixel_line_plot:
-            self.pixel_line_plot.Close()
-            self.pixel_line_plot = None
+        self.update_pixel_line_plot()
 
         if self.settings.show_dials_spotfinder_spots:
             spotfinder_data = self.get_spotfinder_data()
@@ -2066,6 +1828,292 @@ class SpotFrame(XrayFrame):
         except Exception:
             print("Error parsing zeromq message")
             raise
+
+
+class PixelLinePlot(wx.Frame):
+
+    """
+    Class to manage the pixel line plot window, where clicking
+    on a pixel shows a line plot of that pixel across the scan/ToF etc. dimension.
+    """
+
+    def __init__(self, parent: SpotFrame, imageset: ImageSet, **kwargs):
+
+        wx.Frame.__init__(self, parent=parent)
+        self.imageset = imageset
+        self.properties = self.get_properties(**kwargs)
+
+        # Setup blank plot
+        self.figure = Figure(
+            figsize=(self.properties["figsize"]), facecolor=self.properties["facecolor"]
+        )
+        self.axes = self.figure.add_subplot(111)
+        self.canvas = FigureCanvas(self, -1, self.figure)
+        self.sizer = wx.BoxSizer(wx.HORIZONTAL)
+        self.sizer.Add(self.canvas, 1, wx.EXPAND)
+        self.SetSizer(self.sizer)
+        self.set_plot_properties()
+
+        # Params for zooming
+        self.base_zoom_level = 2.0
+
+        # Params for panning
+        self.press = None
+        self.xpress = None
+        self.ypress = None
+        self.x0 = None
+        self.y0 = None
+        self.x1 = None
+        self.y1 = None
+
+        # Bookkeeping to avoid zooming/pannning out of range
+        self.x_range = None
+        self.y_range = None
+
+        # Binding for event handlers
+        self.figure.canvas.mpl_connect("scroll_event", self.zoom_handler)
+        self.figure.canvas.mpl_connect("button_press_event", self.on_press_handler)
+        self.figure.canvas.mpl_connect("button_release_event", self.on_release_handler)
+        self.figure.canvas.mpl_connect("motion_notify_event", self.on_motion_handler)
+        self.Bind(wx.EVT_CLOSE, self.close_window_handler)
+
+        self.Show()
+
+    def update_imageset(self, imageset: ImageSet, **kwargs) -> None:
+
+        """
+        Change the experiment being used in the line plot
+        (i.e when working with multiple datasets)
+        """
+
+        self.imageset = imageset
+        self.properties = self.get_properties(kwargs=kwargs)
+        self.set_plot_properties()
+
+    def set_plot_properties(self) -> None:
+
+        """
+        Adds basic properties to the line plot,
+        based on values in self.properties
+        """
+
+        self.axes.set_xlabel(self.properties["xlabel"])
+        self.axes.set_ylabel(self.properties["ylabel"])
+        self.axes.set_ylim(self.properties["default_ylim"])
+        self.axes.set_xlim(self.properties["default_xlim"])
+        self.axes.patch.set_facecolor(self.properties["facecolor"])
+
+    def close_window_handler(self, event) -> None:
+
+        """
+        Handles when the window is closed by the user
+        """
+
+        self.GetParent().pixel_line_plot_closed()
+        self.Destroy()
+
+    def on_press_handler(self, event) -> None:
+
+        """
+        Press handler for panning
+        """
+
+        if event.inaxes != self.axes:
+            return
+        self.press = self.x0, self.y0, event.xdata, event.ydata
+        self.x0, self.y0, self.xpress, self.ypress = self.press
+
+    def on_release_handler(self, event) -> None:
+
+        """
+        Release handler for panning
+        """
+
+        self.press = None
+        self.canvas.draw()
+
+    def on_motion_handler(self, event, x_only: bool = True) -> None:
+
+        """
+        Motion handler for panning.
+        If x_only, panning is disabled for the y axis.
+        """
+
+        # Sanity check the event should be processed
+        if self.x_range is None or self.y_range is None:
+            return
+        if self.press is None:
+            return
+        if event.inaxes != self.axes:
+            return
+
+        # Handle x axis
+        dx = event.xdata - self.xpress
+        new_x = self.axes.get_xlim() - dx
+        # Only pan if within the range of data
+        if new_x[0] > self.x_range[0] and new_x[1] < self.x_range[1]:
+            self.axes.set_xlim(new_x)
+        if x_only:
+            self.canvas.draw()
+            return
+
+        # Handle y axis
+        dy = event.ydata - self.ypress
+        new_y = self.axes.get_ylim() - dy
+        # Only pan if within the range of data
+        if new_y[0] > self.yrange[0] and new_y[1] < self.y_range[1]:
+            self.axes.set_ylim(new_y)
+
+        self.canvas.draw()
+
+    def zoom_handler(self, event, x_only: bool = True) -> None:
+
+        """
+        Handles all zooming events, bound to the mouse wheel.
+        If x_only, ylim remains constant.
+        """
+
+        # Sanity check event should be processed
+        if self.x_range is None or self.y_range is None:
+            return
+
+        xdata = event.xdata
+        ydata = event.ydata
+
+        if xdata is None or ydata is None:
+            return
+
+        # Get current limits
+        cur_xlim = self.axes.get_xlim()
+        cur_ylim = self.axes.get_ylim()
+
+        # Zoom in
+        if event.button == "down":
+            scale_factor = 1 / self.base_zoom_level
+        # Zoom out
+        elif event.button == "up":
+            scale_factor = self.base_zoom_level
+        # Should never happen
+        else:
+            scale_factor = 1
+
+        # Get new x range and clamp to max x range
+        new_width = (cur_xlim[1] - cur_xlim[0]) * scale_factor
+        new_height = (cur_ylim[1] - cur_ylim[0]) * scale_factor
+
+        relx = (cur_xlim[1] - xdata) / (cur_xlim[1] - cur_xlim[0])
+        rely = (cur_ylim[1] - ydata) / (cur_ylim[1] - cur_ylim[0])
+
+        new_xmin = xdata - new_width * (1 - relx)
+
+        # Clamp to maximum zoom out level
+        if new_xmin < self.x_range[0]:
+            new_xmin = self.x_range[0]
+        new_xmax = xdata + new_width * (relx)
+        if new_xmax > self.x_range[1]:
+            new_xmax = self.x_range[1]
+
+        # Do nothing if trying to zoom in beyond maximum level
+        if new_xmax - new_xmin < self.properties["min_delta_x_range"]:
+            return
+
+        if x_only:
+            self.axes.set_xlim([new_xmin, new_xmax])
+            self.canvas.draw()
+            return
+
+        # Get new y range and clamp to max y range
+        new_ymin = ydata - new_height * (1 - rely)
+        if new_ymin < self.y_range[0]:
+            new_ymin = self.y_range[0]
+        new_ymax = ydata + new_height * (rely)
+        if new_ymax > self.y_range[1]:
+            new_ymax = self.y_range[1]
+
+        # Do nothing if trying to zoom in beyond maximum level
+        if new_ymax - new_ymin < self.properties["min_delta_y_range"]:
+            return
+
+        self.axes.set_ylim([new_ymin, new_ymax])
+
+    def get_properties(self, **kwargs) -> Dict[str, Union[str, int, Tuple]]:
+
+        """
+        Where all plot params are set.
+        """
+
+        default_values = {
+            "facecolor": "#FFE4E4",
+            "linecolor": "black",
+            "bboxcolor": "blue",
+            "centroid_marker_color": "red",
+            "centroid_marker": "x",
+            "centroid_markersize": 15,
+            "figsize": (10, 0.5),
+            "xlabel": "ToF (usec)",
+            "ylabel": "Intensity (AU)",
+            "min_delta_y_range": 1,
+            "min_delta_x_range": 500,
+            "default_xlim": (0, 17500),
+            "default_ylim": (0, 1000),
+        }
+        graph_properties = dict(default_values)
+        graph_properties.update(kwargs)
+        return graph_properties
+
+    def draw(
+        self,
+        panel_idx: int,
+        coords: Tuple,
+        bboxes: Tuple = None,
+        centroids: Tuple = None,
+    ) -> None:
+
+        """
+        Updates the plot with a line plot at coords from panel panel_idx.
+        If bboxes or centroids are given, these are also added to the plot.
+        """
+        px = int(coords[0])
+        py = int(coords[1])
+        x, spectra = self.imageset.get_pixel_spectra(panel_idx, px, py)
+        self.x_range = (min(x), max(x))
+        self.y_range = (min(spectra), max(spectra))
+        self.axes.cla()
+        self.axes.plot(x, spectra, c=self.properties["linecolor"])
+        if bboxes:
+            for bbox in bboxes:
+                x0 = x[bbox[0]]
+                x1 = x[bbox[1]]
+                y0 = min(spectra[bbox[0] : bbox[1]])
+                y1 = max(spectra[bbox[0] : bbox[1]])
+                self.axes.plot(
+                    [x0, x0, x1, x1],
+                    [y0, y1, y1, y0],
+                    lw=1,
+                    c=self.properties["bboxcolor"],
+                )
+        if centroids:
+            for centroid in centroids:
+                cx = x[int(centroid)]
+                cy = spectra[int(centroid)]
+                self.axes.plot(
+                    [cx],
+                    [cy],
+                    self.properties["centroid_marker"],
+                    markersize=self.properties["centroid_markersize"],
+                    c=self.properties["centroid_marker_color"],
+                )
+
+        self.axes.set_title(f"panel {panel_idx} at ({px}, {py})")
+        self.axes.set_xlabel(self.properties["xlabel"])
+        self.axes.set_ylabel(self.properties["ylabel"])
+        self.axes.set_xlim(self.x_range)
+        if self.y_range[1] < self.properties["default_ylim"][1]:
+            self.axes.set_ylim(self.properties["default_ylim"])
+        else:
+            self.axes.set_ylim(self.y_range)
+        self.axes.patch.set_facecolor(self.properties["facecolor"])
+        self.canvas.draw()
 
 
 class SpotSettingsFrame(wx.MiniFrame):

--- a/util/image_viewer/spotfinder_frame.py
+++ b/util/image_viewer/spotfinder_frame.py
@@ -5,6 +5,7 @@ import math
 import wx
 from matplotlib.backends.backend_wxagg import FigureCanvasWxAgg as FigureCanvas
 from matplotlib.figure import Figure
+from wx.core import EVT_LEFT_DOWN
 from wx.lib.intctrl import IntCtrl
 
 from cctbx import crystal, uctbx
@@ -115,6 +116,9 @@ class PixelLinePlot(wx.Frame):
 
         xdata = event.xdata
         ydata = event.ydata
+
+        if xdata is None or ydata is None:
+            return
 
         if event.button == "down":
             # zoom in
@@ -520,6 +524,16 @@ class SpotFrame(XrayFrame):
             self.params.stack_images = value
             self.reload_image()
 
+    def OnLeftClick(self, event):
+        if self.pixel_line_plot and self.current_image_coords:
+            panel, coords = self.current_image_coords
+            self.pixel_line_plot.draw(panel, coords)
+            bboxes, centroids = self.reflections[0].get_pixel_bbox_centroid_positions(
+                panel, coords
+            )
+            self.pixel_line_plot.draw(panel, coords, bboxes, centroids)
+        event.Skip()
+
     def GetBoxCorners(self, layer, p1, p2):
         """Get list of points inside box.
 
@@ -684,81 +698,6 @@ class SpotFrame(XrayFrame):
                     )
                 )
 
-    def handle_position_event(self, event):
-        """Handle a pySlip POSITION event."""
-
-        posn_str = ""
-        if event.position:
-            (lon, lat) = event.position
-            fast_picture, slow_picture = self.pyslip.tiles.lon_lat_to_picture_fast_slow(
-                lon, lat
-            )
-
-            posn_str = "Picture:  slow={:.3f} / fast={:.3f} pixels.".format(
-                slow_picture,
-                fast_picture,
-            )
-            coords = self.pyslip.tiles.get_flex_pixel_coordinates(lon, lat)
-            if len(coords) >= 2:
-                if len(coords) == 3:
-                    readout = int(round(coords[2]))
-                else:
-                    readout = -1
-
-                coords_str = f"slow={coords[0]:.3f} / fast={coords[1]:.3f} pixels"
-                if len(coords) == 2:
-                    posn_str += " Readout: " + coords_str + "."
-                elif readout >= 0:
-                    bboxes, centroids = self.reflections[
-                        0
-                    ].get_pixel_bbox_centroid_positions(readout, coords)
-                    self.pixel_line_plot.draw(readout, coords, bboxes, centroids)
-                    posn_str += " Readout %d: %s." % (readout, coords_str)
-
-                possible_intensity = None
-                fi = self.pyslip.tiles.raw_image
-                detector = fi.get_detector()
-                ifs = (int(coords[1]), int(coords[0]))  # int fast slow
-                isf = (int(coords[0]), int(coords[1]))  # int slow fast
-                image_data = fi.get_image_data()
-                if not isinstance(image_data, tuple):
-                    image_data = (image_data,)
-                if readout >= 0:
-                    if detector[readout].is_coord_valid(ifs):
-                        possible_intensity = image_data[readout][isf]
-
-                if possible_intensity is not None:
-                    if possible_intensity == 0:
-                        format_str = " I=%6.4f"
-                        posn_str += format_str % possible_intensity
-                    elif possible_intensity == MASK_VAL:
-                        posn_str += " I=mask"
-                    else:
-                        yaya = int(math.ceil(math.log10(abs(possible_intensity))))
-                        format_str = " I=%%6.%df" % (max(0, 5 - yaya))
-                        posn_str += format_str % possible_intensity
-
-                if (
-                    len(coords) > 2 and readout >= 0
-                ):  # indicates it's a tiled image in a valid region
-                    reso = self.pyslip.tiles.get_resolution(
-                        coords[1], coords[0], readout
-                    )
-                else:
-                    reso = self.pyslip.tiles.get_resolution(coords[1], coords[0])
-
-                if reso is not None:
-                    posn_str += f" Resolution: {reso:.3f}"
-
-            self.statusbar.SetStatusText(posn_str)
-        else:
-            self.statusbar.SetStatusText(
-                "Click and drag to pan; "
-                + "middle-click and drag to plot intensity profile, right-click to zoom"
-            )
-            # print "event with no position",event
-        return
-
     def add_file_name_or_data(self, image_data):
         """
         Adds an image to the viewer's list of images.
@@ -838,6 +777,8 @@ class SpotFrame(XrayFrame):
             get_image_data=self.get_image_data,
             show_untrusted=show_untrusted,
         )
+
+        self.pyslip.Bind(EVT_LEFT_DOWN, self.OnLeftClick)
 
         # Update the navigation UI controls to reflect this loaded image
         self.image_chooser_panel.SetValue(self.images.selected_index + 1)

--- a/util/image_viewer/spotfinder_frame.py
+++ b/util/image_viewer/spotfinder_frame.py
@@ -47,6 +47,8 @@ try:
 except ImportError:
     pass
 
+from typing import Dict, Tuple, Union
+
 SpotfinderData = collections.namedtuple(
     "SpotfinderData",
     [
@@ -84,10 +86,12 @@ def create_load_image_event(destination, filename):
 
 class PixelLinePlot(wx.Frame):
     def __init__(self, parent, experiment, **kwargs):
+
         wx.Frame.__init__(self, parent=parent)
-        self.base_zoom_level = 2.0
         self.experiment = experiment
         self.properties = self.get_properties(**kwargs)
+
+        # Setup blank plot
         self.figure = Figure(
             figsize=(self.properties["figsize"]), facecolor=self.properties["facecolor"]
         )
@@ -100,19 +104,96 @@ class PixelLinePlot(wx.Frame):
         self.axes.set_ylabel(self.properties["ylabel"])
         self.axes.set_ylim(self.properties["default_ylim"])
         self.axes.set_xlim(self.properties["default_xlim"])
+        self.axes.patch.set_facecolor(self.properties["facecolor"])
+
+        # Params for zooming
+        self.base_zoom_level = 2.0
+
+        # Params for panning
+        self.press = None
+        self.xpress = None
+        self.ypress = None
+        self.x0 = None
+        self.y0 = None
+        self.x1 = None
+        self.y1 = None
+
+        # Bookkeeping to avoid zooming/pannning out of range
         self.x_range = None
         self.y_range = None
-        self.axes.patch.set_facecolor(self.properties["facecolor"])
-        self.Show()
+
+        # Binding for event handlers
         self.figure.canvas.mpl_connect("scroll_event", self.zoom_handler)
+        self.figure.canvas.mpl_connect("button_press_event", self.on_press_handler)
+        self.figure.canvas.mpl_connect("button_release_event", self.on_release_handler)
+        self.figure.canvas.mpl_connect("motion_notify_event", self.on_motion_handler)
 
-    def zoom_handler(self, event, x_only=True):
+        self.Show()
 
+    def on_press_handler(self, event) -> None:
+
+        """
+        Press handler for panning
+        """
+
+        if event.inaxes != self.axes:
+            return
+        self.press = self.x0, self.y0, event.xdata, event.ydata
+        self.x0, self.y0, self.xpress, self.ypress = self.press
+
+    def on_release_handler(self, event) -> None:
+
+        """
+        Release handler for panning
+        """
+
+        self.press = None
+        self.canvas.draw()
+
+    def on_motion_handler(self, event, x_only: bool = True) -> None:
+
+        """
+        Motion handler for panning.
+        If x_only, panning is disabled for the y axis.
+        """
+
+        # Sanity check the event should be processed
         if self.x_range is None or self.y_range is None:
             return
+        if self.press is None:
+            return
+        if event.inaxes != self.axes:
+            return
 
-        cur_xlim = self.axes.get_xlim()
-        cur_ylim = self.axes.get_ylim()
+        # Handle x axis
+        dx = event.xdata - self.xpress
+        new_x = self.axes.get_xlim() - dx
+        # Only pan if within the range of data
+        if new_x[0] > self.x_range[0] and new_x[1] < self.x_range[1]:
+            self.axes.set_xlim(new_x)
+        if x_only:
+            self.canvas.draw()
+            return
+
+        # Handle y axis
+        dy = event.ydata - self.ypress
+        new_y = self.axes.get_ylim() - dy
+        # Only pan if within the range of data
+        if new_y[0] > self.yrange[0] and new_y[1] < self.y_range[1]:
+            self.axes.set_ylim(new_y)
+
+        self.canvas.draw()
+
+    def zoom_handler(self, event, x_only: bool = True) -> None:
+
+        """
+        Handles all zooming events, bound to the mouse wheel.
+        If x_only, ylim remains constant.
+        """
+
+        # Sanity check event should be processed
+        if self.x_range is None or self.y_range is None:
+            return
 
         xdata = event.xdata
         ydata = event.ydata
@@ -120,15 +201,21 @@ class PixelLinePlot(wx.Frame):
         if xdata is None or ydata is None:
             return
 
+        # Get current limits
+        cur_xlim = self.axes.get_xlim()
+        cur_ylim = self.axes.get_ylim()
+
+        # Zoom in
         if event.button == "down":
-            # zoom in
             scale_factor = 1 / self.base_zoom_level
+        # Zoom out
         elif event.button == "up":
-            # zoom out
             scale_factor = self.base_zoom_level
+        # Should never happen
         else:
             scale_factor = 1
 
+        # Get new x range and clamp to max x range
         new_width = (cur_xlim[1] - cur_xlim[0]) * scale_factor
         new_height = (cur_ylim[1] - cur_ylim[0]) * scale_factor
 
@@ -136,12 +223,15 @@ class PixelLinePlot(wx.Frame):
         rely = (cur_ylim[1] - ydata) / (cur_ylim[1] - cur_ylim[0])
 
         new_xmin = xdata - new_width * (1 - relx)
+
+        # Clamp to maximum zoom out level
         if new_xmin < self.x_range[0]:
             new_xmin = self.x_range[0]
         new_xmax = xdata + new_width * (relx)
         if new_xmax > self.x_range[1]:
             new_xmax = self.x_range[1]
 
+        # Do nothing if trying to zoom in beyond maximum level
         if new_xmax - new_xmin < self.properties["min_delta_x_range"]:
             return
 
@@ -150,6 +240,7 @@ class PixelLinePlot(wx.Frame):
             self.canvas.draw()
             return
 
+        # Get new y range and clamp to max y range
         new_ymin = ydata - new_height * (1 - rely)
         if new_ymin < self.y_range[0]:
             new_ymin = self.y_range[0]
@@ -157,12 +248,17 @@ class PixelLinePlot(wx.Frame):
         if new_ymax > self.y_range[1]:
             new_ymax = self.y_range[1]
 
+        # Do nothing if trying to zoom in beyond maximum level
         if new_ymax - new_ymin < self.properties["min_delta_y_range"]:
             return
 
         self.axes.set_ylim([new_ymin, new_ymax])
 
-    def get_properties(self, **kwargs):
+    def get_properties(self, **kwargs) -> Dict[str, Union[str, int, Tuple]]:
+
+        """
+        Where all plot params are set.
+        """
 
         default_values = {
             "facecolor": "#FFE4E4",
@@ -183,7 +279,18 @@ class PixelLinePlot(wx.Frame):
         graph_properties.update(kwargs)
         return graph_properties
 
-    def draw(self, panel_idx, coords, bboxes=None, centroids=None):
+    def draw(
+        self,
+        panel_idx: int,
+        coords: Tuple,
+        bboxes: Tuple = None,
+        centroids: Tuple = None,
+    ) -> None:
+
+        """
+        Updates the plot with a line plot at coords from panel panel_idx.
+        If bboxes or centroids are given, these are also added to the plot.
+        """
         px = int(coords[0])
         py = int(coords[1])
         x, spectra = self.experiment.imageset.get_pixel_spectra(panel_idx, px, py)

--- a/util/image_viewer/spotfinder_frame.py
+++ b/util/image_viewer/spotfinder_frame.py
@@ -1389,7 +1389,7 @@ class SpotFrame(XrayFrame):
         vector_data = []
         vector_text_data = []
         detector = self.pyslip.tiles.raw_image.get_detector()
-        scan = self.pyslip.tiles.raw_image.get_scan()
+        scan = self.pyslip.tiles.raw_image.get_sequence()
         to_degrees = 180 / math.pi
         # self.prediction_colours = ["#a6cee3", "#1f78b4", "#b2df8a", "#33a02c",
         # "#fb9a99", "#e31a1c", "#fdbf6f", "#ff7f00",

--- a/util/image_viewer/spotfinder_frame.py
+++ b/util/image_viewer/spotfinder_frame.py
@@ -92,6 +92,7 @@ class SpotFrame(XrayFrame):
         self.imagesets = list(
             itertools.chain(*[x.imagesets() for x in self.experiments])
         )
+        self.current_imageset = None
         self.crystals = list(itertools.chain(*[x.crystals() for x in self.experiments]))
         if len(self.imagesets) == 0:
             raise RuntimeError("No imageset could be constructed")
@@ -235,6 +236,13 @@ class SpotFrame(XrayFrame):
         )
         return pixel_line_plot
 
+    def imageset_valid_for_pixel_line_plot(self, imageset: ImageSet) -> bool:
+        if ImageSet.is_sequence(imageset):
+            fmt_inst = imageset.get_format_class().get_instance(imageset.get_template())
+            if hasattr(fmt_inst, "get_pixel_spectra"):
+                return True
+        return False
+
     def update_pixel_line_plot(self) -> None:
 
         """
@@ -243,6 +251,18 @@ class SpotFrame(XrayFrame):
         """
 
         imageset = self.images.selected.image_set
+        # Check if not imageset experiment can have a PixelLinePlot
+        if imageset is not self.current_imageset:
+            if self.imageset_valid_for_pixel_line_plot(imageset):
+                self.settings_frame.panel.show_pixel_line_plot.Enable(True)
+            else:
+                # Disable the control to turn on the line plot
+                # and close any active window
+                self.settings_frame.panel.show_pixel_line_plot.Enable(False)
+                if self.pixel_line_plot:
+                    self.pixel_line_plot_closed()
+                return
+
         reflection_table_list = self.get_imageset_reflection_table_list(imageset)
 
         # Create a new pixel line plot if not active and one is requested
@@ -268,6 +288,7 @@ class SpotFrame(XrayFrame):
         (called when the window is closed)
         """
 
+        self.pixel_line_plot.Destroy()
         self.pixel_line_plot = None
         self.show_pixel_line_plot = False
         self.settings_frame.panel.show_pixel_line_plot.SetValue(False)
@@ -1108,6 +1129,7 @@ class SpotFrame(XrayFrame):
 
     def update_settings(self, layout=True):
         # super(SpotFrame, self).update_settings(layout=layout)
+
         new_brightness = self.settings.brightness
         new_color_scheme = self.settings.color_scheme
         if (
@@ -1132,6 +1154,7 @@ class SpotFrame(XrayFrame):
             self.beam_layer = None
 
         self.update_pixel_line_plot()
+        self.current_imageset = self.images.selected.image_set
 
         if self.settings.show_dials_spotfinder_spots:
             spotfinder_data = self.get_spotfinder_data()
@@ -1868,6 +1891,7 @@ class PixelLinePlot(wx.Frame):
     ):
 
         wx.Frame.__init__(self, parent=parent)
+        self.SetTitle("Pixel Line Plot")
         self.imageset = imageset
         self.reflection_table_list = reflection_table_list
         self.properties = self.get_properties(**kwargs)
@@ -1944,7 +1968,6 @@ class PixelLinePlot(wx.Frame):
         """
 
         self.GetParent().pixel_line_plot_closed()
-        self.Destroy()
 
     def on_press_handler(self, event) -> None:
 
@@ -2081,7 +2104,7 @@ class PixelLinePlot(wx.Frame):
             "linecolor": "black",
             "bboxcolor": "blue",
             "centroid_marker_color": "red",
-            "centroid_marker": "x",
+            "centroid_marker": "+",
             "centroid_markersize": 15,
             "figsize": (10, 0.5),
             "xlabel": "ToF (usec)",
@@ -2396,6 +2419,15 @@ class SpotSettingsPanel(wx.Panel):
         self.show_pixel_line_plot = wx.CheckBox(self, -1, "Show pixel line plot")
         self.show_pixel_line_plot.SetValue(self.settings.show_pixel_line_plot)
         grid.Add(self.show_pixel_line_plot, 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL, 5)
+        if (
+            not self.GetParent()
+            .GetParent()
+            .imageset_valid_for_pixel_line_plot(
+                self.GetParent().GetParent().images.selected.image_set
+            )
+        ):
+            self.show_pixel_line_plot.SetValue(False)
+            self.show_pixel_line_plot.Enable(False)
 
         grid = wx.FlexGridSizer(cols=2, rows=1, vgap=0, hgap=0)
         self.clear_all_button = wx.Button(self, -1, "Clear all")

--- a/util/image_viewer/spotfinder_frame.py
+++ b/util/image_viewer/spotfinder_frame.py
@@ -127,8 +127,13 @@ class PixelLinePlot(wx.Frame):
         self.figure.canvas.mpl_connect("button_press_event", self.on_press_handler)
         self.figure.canvas.mpl_connect("button_release_event", self.on_release_handler)
         self.figure.canvas.mpl_connect("motion_notify_event", self.on_motion_handler)
+        self.Bind(wx.EVT_CLOSE, self.close_window_handler)
 
         self.Show()
+
+    def close_window_handler(self, event) -> None:
+        self.GetParent().pixel_line_plot_closed()
+        self.Destroy()
 
     def on_press_handler(self, event) -> None:
 
@@ -430,7 +435,7 @@ class SpotFrame(XrayFrame):
         self.mask_image_viewer = None
         self._mask_frame = None
 
-        self.pixel_line_plot = self.get_pixel_line_plot()
+        self.pixel_line_plot = None
 
         self.display_foreground_circles_patch = False  # hard code this option, for now
 
@@ -465,11 +470,27 @@ class SpotFrame(XrayFrame):
         self.Bind(wx.EVT_UPDATE_UI, self.OnUpdateUIMask, id=self._id_mask)
         self.Bind(EVT_ZEROMQ_EVENT, self.OnZeroMQEvent)
 
-    def get_pixel_line_plot(self, **kwargs):
+    def get_pixel_line_plot(self, **kwargs) -> PixelLinePlot:
+
+        """
+        Creates and returns a pixel line plot
+        """
+
         pixel_line_plot = PixelLinePlot(self, self.experiments[0][0], kwargs=kwargs)
         pixel_line_plot.SetSize(1024, 450)
         pixel_line_plot.SetPosition((0, self.GetSize()[0] - 500))
         return pixel_line_plot
+
+    def pixel_line_plot_closed(self) -> None:
+
+        """
+        Resets pixel line plot values
+        (called when the window is closed)
+        """
+
+        self.pixel_line_plot = None
+        self.show_pixel_line_plot = False
+        self.settings_frame.panel.show_pixel_line_plot.SetValue(False)
 
     def setup_toolbar(self):
         btn = self.toolbar.AddTool(
@@ -1329,6 +1350,12 @@ class SpotFrame(XrayFrame):
         elif self.beam_layer is not None:
             self.pyslip.DeleteLayer(self.beam_layer, update=False)
             self.beam_layer = None
+
+        if self.settings.show_pixel_line_plot and not self.pixel_line_plot:
+            self.pixel_line_plot = self.get_pixel_line_plot()
+        elif not self.settings.show_pixel_line_plot and self.pixel_line_plot:
+            self.pixel_line_plot.Close()
+            self.pixel_line_plot = None
 
         if self.settings.show_dials_spotfinder_spots:
             spotfinder_data = self.get_spotfinder_data()
@@ -2273,9 +2300,9 @@ class SpotSettingsPanel(wx.Panel):
         grid.Add(self.integrated, 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL, 5)
 
         # Toggle pixel line plot
-        self.pixel_line_plot = wx.CheckBox(self, -1, "Show pixel line plot")
-        self.pixel_line_plot.SetValue(self.settings.show_pixel_line_plot)
-        grid.Add(self.pixel_line_plot, 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL, 5)
+        self.show_pixel_line_plot = wx.CheckBox(self, -1, "Show pixel line plot")
+        self.show_pixel_line_plot.SetValue(self.settings.show_pixel_line_plot)
+        grid.Add(self.show_pixel_line_plot, 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL, 5)
 
         grid = wx.FlexGridSizer(cols=2, rows=1, vgap=0, hgap=0)
         self.clear_all_button = wx.Button(self, -1, "Clear all")
@@ -2476,6 +2503,7 @@ class SpotSettingsPanel(wx.Panel):
         self.Bind(wx.EVT_CHECKBOX, self.OnUpdate, self.indexed)
         self.Bind(wx.EVT_CHECKBOX, self.OnUpdate, self.integrated)
         self.Bind(wx.EVT_CHECKBOX, self.OnUpdate, self.show_basis_vectors)
+        self.Bind(wx.EVT_CHECKBOX, self.OnUpdate, self.show_pixel_line_plot)
         self.Bind(wx.EVT_CHECKBOX, self.OnUpdateShowMask, self.show_mask)
 
         self.Bind(wx.EVT_UPDATE_UI, self.UpdateZoomCtrl)
@@ -2531,6 +2559,7 @@ class SpotSettingsPanel(wx.Panel):
             self.settings.min_local = self.min_local_ctrl.GetPhilValue()
             self.settings.gain = self.gain_ctrl.GetPhilValue()
             self.settings.find_spots_phil = self.save_params_txt_ctrl.GetPhilValue()
+            self.settings.show_pixel_line_plot = self.show_pixel_line_plot.GetValue()
 
     def UpdateZoomCtrl(self, event):
         self.settings.zoom_level = self.levels.index(


### PR DESCRIPTION
Added generic image viewer line plot to `dials.image_viewer`, primarily to allow users to view the ToF dimension of a given pixel. 

- Users can show/hide the line plot using the settings panel
- Left clicking on a pixel with the line plot open then shows a plot of the pixel values throughout the stack of the imageset
- Users can zoom, pan, and see bounding boxes/centroids
- This works based if the imageset is an imagesequence, and if the corresponding format class has a get_pixel_spectra method. If  either of these are false the setting is disabled.
- Works with multiple imagesets