### PR TITLE
Updated weighting strategy after looking at more datasets.

### DIFF
--- a/src/dials/algorithms/refinement/weighting_strategies.py
+++ b/src/dials/algorithms/refinement/weighting_strategies.py
@@ -99,26 +99,15 @@ class ConstantWeightingStrategy:
 
 
 class TOFWeightingStrategy(StatisticalWeightingStrategy):
-    """Defines a single method that provides a ReflectionManager with a strategy
-    for calculating weights for refinement. This version uses statistical weights
-    for X and Y and a fixed constant for the delta Psi part, defaulting to 1000000"""
-
     def __init__(self):
         pass
 
     def calculate_weights(self, reflections):
-        """Include weights for DeltaPsi"""
 
-        # call parent class method to set X and Y weights
         reflections = super().calculate_weights(reflections)
 
         wx, wy, _ = reflections["xyzobs.mm.weights"].parts()
-        wavelength_var = (
-            reflections["wavelength"]
-            - sum(reflections["wavelength"]) / len(reflections)
-        ) ** 2
-        wz = 1 / wavelength_var
-        wz = wy * 1260000
+        wz = flex.sqrt(wx * wx + wy * wy) * 1e7
         reflections["xyzobs.mm.weights"] = flex.vec3_double(wx, wy, wz)
 
         return reflections


### PR DESCRIPTION
Weighting of wavelength term during refinement was updated based on optimum values for different datasets.

![SXD NaCl](https://github.com/toastisme/dials/assets/60879630/33d3542b-0cc9-420c-9a93-e3a42650e848)
![SXD Rubredoxine](https://github.com/toastisme/dials/assets/60879630/98a1ae1e-08ef-4435-87fa-be28333f5b46)
![NMX Rubredoxine](https://github.com/toastisme/dials/assets/60879630/4e8e2142-1c0d-4821-8e22-d18407b2dac0)
![SXD Lead Triacetate](https://github.com/toastisme/dials/assets/60879630/88a86435-ac9a-4d5c-89bf-ae8627c2b8f0)
![SXD L-Alanine](https://github.com/toastisme/dials/assets/60879630/22a7fda1-cda2-4dc0-8fbd-35c2748c4070)
